### PR TITLE
Fix typo in publish_tf parameter declaration

### DIFF
--- a/src/openvslam_ros.cc
+++ b/src/openvslam_ros.cc
@@ -74,7 +74,7 @@ void system::setParams() {
 
     // Set publish_tf to false if not using TF
     publish_tf_ = true;
-    private_nh_.param("publish_tf_", publish_tf_, publish_tf_);
+    private_nh_.param("publish_tf", publish_tf_, publish_tf_);
 
     // Publish pose's timestamp in the future
     transform_tolerance_ = 0.5;


### PR DESCRIPTION
Fix for a small typo in the declaration of the `publish_tf` parameter.