### PR TITLE
Publish pose to camera_frame

### DIFF
--- a/src/openvslam_ros.h
+++ b/src/openvslam_ros.h
@@ -38,7 +38,8 @@ public:
     ros::Publisher pose_pub_;
     ros::Subscriber init_pose_sub_;
     std::shared_ptr<tf2_ros::TransformBroadcaster> map_to_odom_broadcaster_;
-    std::string odom_frame_, map_frame_, base_link_, camera_link_;
+    std::string odom_frame_, map_frame_, base_link_;
+    std::string camera_frame_, camera_optical_frame_;
     std::unique_ptr<tf2_ros::Buffer> tf_;
     std::shared_ptr<tf2_ros::TransformListener> transform_listener_;
     bool publish_tf_;


### PR DESCRIPTION
See http://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/Image.html.

The frame_id of the image is supposed to follow the optical frame.
If you want to visualize the camera pose with rviz, you should output the pose to the camera frame instead of the camera optical frame.